### PR TITLE
change: Clarified "cloud" and "server" for GitHub Enterprise

### DIFF
--- a/docs/github-enterprise.md
+++ b/docs/github-enterprise.md
@@ -13,8 +13,8 @@ github-comment >= [v4.2.0](https://github.com/suzuki-shunsuke/github-comment/rel
 Please set the following fields in configuration file `github-comment.yaml`.
 
 ```yaml
-ghe_base_url: https://api.github.com # CHANGE
-ghe_graphql_endpoint: https://api.github.com/graphql # CHANGE
+ghe_base_url: http(s)://<your_enterprise_hostname> # CHANGE
+ghe_graphql_endpoint: http(s)://<your_enterprise_hostname>/api/graphql # CHANGE
 ```
 
 * https://docs.github.com/en/enterprise-server@3.5/rest/overview/resources-in-the-rest-api#current-version

--- a/docs/github-enterprise.md
+++ b/docs/github-enterprise.md
@@ -12,10 +12,21 @@ github-comment >= [v4.2.0](https://github.com/suzuki-shunsuke/github-comment/rel
 
 Please set the following fields in configuration file `github-comment.yaml`.
 
+GitHub Enterprise Server
 ```yaml
 ghe_base_url: http(s)://<your_enterprise_hostname> # CHANGE
 ghe_graphql_endpoint: http(s)://<your_enterprise_hostname>/api/graphql # CHANGE
 ```
 
-* https://docs.github.com/en/enterprise-server@3.5/rest/overview/resources-in-the-rest-api#current-version
-* https://docs.github.com/en/enterprise-server@2.20/graphql/guides/forming-calls-with-graphql#the-graphql-endpoint
+See. https://docs.github.com/en/enterprise-server/graphql/guides/forming-calls-with-graphql#the-graphql-endpoint
+
+GitHub Enterprise Cloud
+```yaml
+ghe_base_url: https://api.github.com
+ghe_graphql_endpoint: https://api.github.com/graphql
+```
+
+See. https://docs.github.com/en/enterprise-cloud@latest/graphql/guides/forming-calls-with-graphql#the-graphql-endpoint
+
+- https://docs.github.com/en/enterprise-server@3.5/rest/overview/resources-in-the-rest-api#current-version
+- https://docs.github.com/en/enterprise-server@2.20/graphql/guides/forming-calls-with-graphql#the-graphql-endpoint


### PR DESCRIPTION
Hi @suzuki-shunsuke
Thank you for developing this tool.

I notice a little confusing point about GraphQL API endpoint when reading this docs.
The GitHub Enterprise (Cloud/Server) have different GraphQL API endpoint, so I thought it would be easier to understand if each item was written separetely.

GitHub Enterprise Server
```
http(s)://<HOSTNAME>/api/graphql
```
https://docs.github.com/en/enterprise-server@3.11/graphql/guides/forming-calls-with-graphql#the-graphql-endpoint

GitHub Enterprise Cloud
```
https://api.github.com/graphql
```
https://docs.github.com/en/enterprise-cloud@latest/graphql/guides/forming-calls-with-graphql#the-graphql-endpoint

We are using the "GitHub Enterprise Server", so I was little confused when read the document. because our GitHub Enterprise Server hasn't the `api.<our github enterprise hostname>` endpoint and path of `/graphql` like a cloud version.